### PR TITLE
Sparse TNEANet

### DIFF
--- a/snap-core/mmnet.cpp
+++ b/snap-core/mmnet.cpp
@@ -14,9 +14,17 @@ TStr TModeNet::GetNeighborCrossName(const TStr& CrossName, bool isOutEdge, const
 
 void TModeNet::ClrNbr(const TStr& CrossNetName, const bool& outEdge, const bool& sameMode, bool& isDir) {
   TStr Name = GetNeighborCrossName(CrossNetName, outEdge, sameMode, isDir);
-  TVec<TIntV> Attrs(MxNId);
+  TInt location = CheckDenseOrSparseN(Name);
   int index = KeyToIndexTypeN.GetDat(Name).Val2;
-  VecOfIntVecVecsN[index] = Attrs;
+  if (location == 1) {
+    TVec<TIntV> Attrs(MxNId);
+    VecOfIntVecVecsN[index] = Attrs;
+  } else {
+    THash<TInt, TIntV> Attrs;
+    VecOfIntHashVecsN[index] = Attrs;
+  }
+  
+  
 }
 
 void TModeNet::Clr() {
@@ -114,12 +122,36 @@ void TModeNet::GetNeighborsByCrossNet(const int& NId, TStr& Name, TIntV& Neighbo
   }
 }
 
-int TModeNet::AddIntVAttrByVecN(const TStr& attr, TVec<TIntV>& Attrs){
+int TModeNet::AddIntVAttrByVecN(const TStr& attr, TVec<TIntV>& Attrs, TBool UseDense){
   TInt CurrLen;
-  TVec<TIntV> NewVec;
-  CurrLen = VecOfIntVecVecsN.Len();
+  if (UseDense) {
+    CurrLen = VecOfIntVecVecsN.Len();
+    KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
+    KeyToDenseN.AddDat(attr, true);
+    VecOfIntVecVecsN.Add(Attrs);
+  } else {
+    THash<TInt, TIntV> NewHash;
+    CurrLen = VecOfIntHashVecsN.Len();
+    KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
+    KeyToDenseN.AddDat(attr, false);
+    for (int i=0; i< Attrs.Len(); i++) {
+      NewHash.AddDat(i, Attrs[i]);
+    }
+    VecOfIntHashVecsN.Add(NewHash);
+  }
+  return 0;
+}
+
+int TModeNet::AddIntVAttrByHashN(const TStr& attr, THash<TInt, TIntV>& Attrs){
+  TInt CurrLen;
+  THash<TInt, TIntV> NewHash;
+  CurrLen = VecOfIntHashVecsN.Len();
   KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
-  VecOfIntVecVecsN.Add(Attrs);
+  KeyToDenseN.AddDat(attr, false);
+  for (int i=0; i< Attrs.Len(); i++) {
+    NewHash.AddDat(i, Attrs[i]);
+  }
+  VecOfIntHashVecsN.Add(NewHash);
   return 0;
 }
 
@@ -145,12 +177,26 @@ void TModeNet::RemoveCrossNets(TModeNet& Result, TStrV& CrossNets) {
         TStr NbrName = isSingleVNbrAttr ? AttrName : WithoutSuffix;
         if (CrossNets.IsIn(NbrName)) {
           Result.AddNbrType(NbrName, removeSuffix, removeSuffix);
-          TVec<TIntV>& Attrs = VecOfIntVecVecsN[AttrIndex];
-          Result.AddIntVAttrByVecN(AttrName, Attrs);
+          TInt location = CheckDenseOrSparseN(AttrName);
+          if (location == 1) {
+            TVec<TIntV>& Attrs = VecOfIntVecVecsN[AttrIndex];
+            Result.AddIntVAttrByVecN(AttrName, Attrs);
+          } else {
+            THash<TInt, TIntV>& Attrs = VecOfIntHashVecsN[AttrIndex];
+            Result.AddIntVAttrByHashN(AttrName, Attrs);
+          }
+          
         }
       } else {
-        TVec<TIntV>& Attrs = VecOfIntVecVecsN[AttrIndex];
-        Result.AddIntVAttrByVecN(AttrName, Attrs);
+        TInt location = CheckDenseOrSparseN(AttrName);
+        if (location == 1) {
+          TVec<TIntV>& Attrs = VecOfIntVecVecsN[AttrIndex];
+          Result.AddIntVAttrByVecN(AttrName, Attrs);
+        } else {
+          THash<TInt, TIntV>& Attrs = VecOfIntHashVecsN[AttrIndex];
+          Result.AddIntVAttrByHashN(AttrName, Attrs);
+        }
+        
       }
     }
   }

--- a/snap-core/mmnet.h
+++ b/snap-core/mmnet.h
@@ -88,10 +88,12 @@ public:
     if (this!=&Graph) {
       MxNId=Graph.MxNId; MxEId=Graph.MxEId; NodeH=Graph.NodeH; EdgeH=Graph.EdgeH;
       KeyToIndexTypeN=Graph.KeyToIndexTypeN; KeyToIndexTypeE=Graph.KeyToIndexTypeE;
+      KeyToDenseN = Graph.KeyToDenseN; KeyToDenseE = Graph.KeyToDenseE;
       IntDefaultsN=Graph.IntDefaultsN; IntDefaultsE=Graph.IntDefaultsE; StrDefaultsN=Graph.StrDefaultsN; StrDefaultsE=Graph.StrDefaultsE;
       FltDefaultsN=Graph.FltDefaultsN; FltDefaultsE=Graph.FltDefaultsE; VecOfIntVecsN=Graph.VecOfIntVecsN; VecOfIntVecsE=Graph.VecOfIntVecsE;
       VecOfStrVecsN=Graph.VecOfStrVecsN; VecOfStrVecsE=Graph.VecOfStrVecsE; VecOfFltVecsN=Graph.VecOfFltVecsN; VecOfFltVecsE=Graph.VecOfFltVecsE;
-      VecOfIntVecVecsN=Graph.VecOfIntVecVecsN; VecOfIntVecVecsE=Graph.VecOfIntVecVecsE; SAttrN=Graph.SAttrN; SAttrE=Graph.SAttrE;
+      VecOfIntVecVecsN=Graph.VecOfIntVecVecsN; VecOfIntVecVecsE=Graph.VecOfIntVecVecsE; 
+      VecOfIntHashVecsN = Graph.VecOfIntHashVecsN; VecOfIntHashVecsE = Graph.VecOfIntHashVecsE; SAttrN=Graph.SAttrN; SAttrE=Graph.SAttrE;
       ModeId=Graph.ModeId; MMNet=Graph.MMNet; NeighborTypes=Graph.NeighborTypes;
     }
     return *this; 
@@ -107,7 +109,8 @@ private:
   void SetParentPointer(TMMNet* parent);
   int AddNbrType(const TStr& CrossName, const bool sameMode, bool isDir);
   /// Adds a new TIntV node attribute to the hashmap.
-  int AddIntVAttrByVecN(const TStr& attr, TVec<TIntV>& Attrs);
+  int AddIntVAttrByVecN(const TStr& attr, TVec<TIntV>& Attrs, TBool UseDense=true);
+  int AddIntVAttrByHashN(const TStr& attr, THash<TInt, TIntV>& Attrs);
   void RemoveCrossNets(TModeNet& Result, TStrV& CrossNets);
   int DelNbrType(const TStr& CrossName);
   int GetAttrTypeN(const TStr& attr) const;

--- a/snap-core/mmnet.h
+++ b/snap-core/mmnet.h
@@ -614,6 +614,12 @@ public:
   }
   static PMMNet New() { return PMMNet(new TMMNet()); }
 
+  void ConvertToSparse() {
+    for (THash<TInt, TModeNet>::TIter it = TModeNetH.BegI(); it < TModeNetH.EndI(); it++) {
+      it.GetDat().ConvertToSparse();
+    }
+  }
+
   /// Gets the mode id from the mode name.
   int GetModeId(const TStr& ModeName) const { if (ModeNameToIdH.IsKey(ModeName)) { return ModeNameToIdH.GetDat(ModeName); } else { return -1; }  }
   /// Gets the mode name from the mode id.

--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -9,6 +9,10 @@ void TNEANet::LoadNetworkShm(TShMIn& ShMin) {
       EdgeH.LoadShM(ShMin);
       KeyToIndexTypeN.LoadShM(ShMin);
       KeyToIndexTypeE.LoadShM(ShMin);
+      
+      KeyToDenseN.LoadShM(ShMin);
+      KeyToDenseE.LoadShM(ShMin);
+
       IntDefaultsN.LoadShM(ShMin);
       IntDefaultsE.LoadShM(ShMin);
       StrDefaultsN.LoadShM(ShMin);
@@ -28,6 +32,10 @@ void TNEANet::LoadNetworkShm(TShMIn& ShMin) {
       LoadVecOfVecFunctor vec_of_vec_fn;
       VecOfIntVecVecsN.LoadShM(ShMin, vec_of_vec_fn);
       VecOfIntVecVecsE.LoadShM(ShMin, vec_of_vec_fn);
+
+      LoadHashOfVecFunctor hash_of_vec_fn;
+      VecOfIntHashVecsN.LoadShM(ShMin, hash_of_vec_fn);
+      VecOfIntHashVecsE.LoadShM(ShMin, hash_of_vec_fn);
 
       /* Attributes are complicated so load these straight */
       SAttrN.Load(ShMin);

--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -112,11 +112,21 @@ void TNEANet::IntVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TI
   Values = TVec<TIntV>();
   while (!NodeHI.IsEnd()) {
     if (NodeHI.GetDat().Val1 == IntVType) {
-      TIntV val = this->VecOfIntVecVecsN.GetVal(NodeHI.GetDat().Val2).GetVal(NodeH.GetKeyId(NId));
-      Values.Add(val);
+      TInt index = NodeHI.GetDat().Val2;
+      TStr attr =  NodeHI.GetKey();
+      TInt loc = CheckDenseOrSparseN(attr);
+      if (loc == 1) {
+        TIntV val = this->VecOfIntVecVecsN.GetVal(index).GetVal(NodeH.GetKeyId(NId));
+        if (val.Len() != 0) Values.Add(val);
+      } else {
+        const THash<TInt, TIntV>& NewHash = VecOfIntHashVecsN[index];
+        if (NewHash.IsKey(NodeH.GetKeyId(NId))) {
+          Values.Add(NewHash[NodeH.GetKeyId(NId)]);
+        }
+      }
     }
     NodeHI++;
-  }  
+  }
 }
 
 void TNEANet::StrAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const {
@@ -294,11 +304,21 @@ void TNEANet::IntVAttrValueEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TVec<TI
   Values = TVec<TIntV>();
   while (!EdgeHI.IsEnd()) {
     if (EdgeHI.GetDat().Val1 == IntVType) {
-      TIntV val = (this->VecOfIntVecVecsE.GetVal(EdgeHI.GetDat().Val2).GetVal(EId));
-      Values.Add(val);
+      TInt index = EdgeHI.GetDat().Val2;
+      TStr attr =  EdgeHI.GetKey();
+      TInt loc = CheckDenseOrSparseE(attr);
+      if (loc == 1) {
+        TIntV val = this->VecOfIntVecVecsE.GetVal(index).GetVal(EdgeH.GetKeyId(EId));
+        if (val.Len() != 0) Values.Add(val);
+      } else {
+        const THash<TInt, TIntV>& NewHash = VecOfIntHashVecsE[index];
+        if (NewHash.IsKey(EdgeH.GetKeyId(EId))) {
+          Values.Add(NewHash[EdgeH.GetKeyId(EId)]);
+        }
+      }
     }
     EdgeHI++;
-  }  
+  }
 }
 
 void TNEANet::StrAttrNameEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TStrV& Names) const {
@@ -528,6 +548,12 @@ void TNEANet::DelNode(const int& NId) {
       IntVecV[EdgeH.GetKeyId(EId)] = TIntV();
     }
     EdgeH.DelKey(EId);
+    for (i = 0; i < VecOfIntHashVecsE.Len(); i++) {
+      THash<TInt, TIntV>& IntHashV = VecOfIntHashVecsE[i];
+      if (IntHashV.IsKey(EdgeH.GetKeyId(EId))) {
+        IntHashV.DelKey(EdgeH.GetKeyId(EId));
+      }
+    }
   }
   for (int in = 0; in < Node.GetInDeg(); in++) {
     const int EId = Node.GetInEId(in);
@@ -551,6 +577,12 @@ void TNEANet::DelNode(const int& NId) {
       TVec<TIntV>& IntVecV = VecOfIntVecVecsE[i];
       IntVecV[EdgeH.GetKeyId(EId)] = TIntV();
     }
+    for (i = 0; i < VecOfIntHashVecsE.Len(); i++) {
+      THash<TInt, TIntV>& IntHashV = VecOfIntHashVecsE[i];
+      if (IntHashV.IsKey(EdgeH.GetKeyId(EId))) {
+        IntHashV.DelKey(EdgeH.GetKeyId(EId));
+      }
+    }
     EdgeH.DelKey(EId);
   }
 
@@ -569,6 +601,12 @@ void TNEANet::DelNode(const int& NId) {
   for (i = 0; i < VecOfIntVecVecsN.Len(); i++) {
     TVec<TIntV>& IntVecV = VecOfIntVecVecsN[i];
     IntVecV[NodeH.GetKeyId(NId)] = TIntV();
+  }
+  for (i = 0; i < VecOfIntHashVecsN.Len(); i++) {
+    THash<TInt, TIntV>& IntHashV = VecOfIntHashVecsN[i];
+    if (IntHashV.IsKey(NodeH.GetKeyId(NId))) {
+      IntHashV.DelKey(NodeH.GetKeyId(NId));
+    }
   }
   NodeH.DelKey(NId);
 }
@@ -868,41 +906,47 @@ int TNEANet::AddIntAttrDatN(const int& NId, const TInt& value, const TStr& attr)
   return 0;
 }
 
-int TNEANet::AddIntVAttrDatN(const int& NId, const TIntV& value, const TStr& attr) {
-  TInt CurrLen;
+int TNEANet::AddIntVAttrDatN(const int& NId, const TIntV& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(NId)) {
     // AddNode(NId);
     return -1;
   }
-  if (KeyToIndexTypeN.IsKey(attr)) {
+  TInt location = CheckDenseOrSparseN(attr);
+  if (location==-1) {
+    AddIntVAttrN(attr, UseDense);
+    location = CheckDenseOrSparseN(attr);
+  }
+  if (UseDense) {
+    IAssertR(location != 0, TStr::Fmt("NodeId %d exists for %s in sparse representation", NId, attr.CStr()));
     TVec<TIntV>& NewVec = VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
     NewVec[NodeH.GetKeyId(NId)] = value;
   } else {
-    CurrLen = VecOfIntVecVecsN.Len();
-    KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
-    TVec<TIntV> NewVec = TVec<TIntV>(MxNId);
-    NewVec[NodeH.GetKeyId(NId)] = value;
-    VecOfIntVecVecsN.Add(NewVec);
+    IAssertR(location != 1, TStr::Fmt("NodeId %d exists for %s in dense representation", NId, attr.CStr()));
+    THash<TInt, TIntV>& NewHash = VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
+    NewHash.AddDat(NodeH.GetKeyId(NId), value);
   }
+  
   return 0;
 } 
 
-int TNEANet::AppendIntVAttrDatN(const int& NId, const TInt& value, const TStr& attr) {
-  TInt CurrLen;
+int TNEANet::AppendIntVAttrDatN(const int& NId, const TInt& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(NId)) {
     // AddNode(NId);
     return -1;
   }
-  if (KeyToIndexTypeN.IsKey(attr)) {
+  TInt location = CheckDenseOrSparseN(attr);
+  if (location==-1) {
+    AddIntVAttrN(attr, UseDense);
+    location = CheckDenseOrSparseN(attr);
+  }
+  if (UseDense) {
+    IAssertR(location != 0, TStr::Fmt("NodeId %d exists for %s in sparse representation", NId, attr.CStr()));
     TVec<TIntV>& NewVec = VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
     NewVec[NodeH.GetKeyId(NId)].Add(value);
   } else {
-    CurrLen = VecOfIntVecVecsN.Len();
-    KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
-    TVec<TIntV> NewVec;
-    VecOfIntVecVecsN.Add(NewVec);
-    VecOfIntVecVecsN[CurrLen].Gen(MxNId);
-    VecOfIntVecVecsN[CurrLen][NodeH.GetKeyId(NId)].Add(value);
+    IAssertR(location != 1, TStr::Fmt("NodeId %d exists for %s in dense representation", NId, attr.CStr()));
+    THash<TInt, TIntV>& NewHash = VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
+    NewHash[NodeH.GetKeyId(NId)].Add(value);
   }
   return 0;
 } 
@@ -913,10 +957,18 @@ int TNEANet::DelFromIntVAttrDatN(const int& NId, const TInt& value, const TStr& 
     // AddNode(NId);
     return -1;
   }
-  if (KeyToIndexTypeN.IsKey(attr)) {
-    TVec<TIntV>& NewVec = VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
-    if (!NewVec[NodeH.GetKeyId(NId)].DelIfIn(value)) {
-      return -1;
+  TInt location = CheckDenseOrSparseN(attr);
+  if (location != -1) {
+    if (location == 1) {
+      TVec<TIntV>& NewVec = VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
+      if (!NewVec[NodeH.GetKeyId(NId)].DelIfIn(value)) {
+        return -1;
+      }
+    } else {
+      THash<TInt, TIntV>& NewHash = VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2];
+      if (!NewHash[NodeH.GetKeyId(NId)].DelIfIn(value)) {
+        return -1;
+      }
     }
   } else {
     return -1;
@@ -994,40 +1046,43 @@ int TNEANet::AddIntAttrDatE(const int& EId, const TInt& value, const TStr& attr)
   return 0;
 }
 
-int TNEANet::AddIntVAttrDatE(const int& EId, const TIntV& value, const TStr& attr) {
-  int i;
-  TInt CurrLen;
-  if (!IsEdge(EId)) {
-    //AddEdge(EId);
-     return -1;
+int TNEANet::AddIntVAttrDatE(const int& EId, const TIntV& value, const TStr& attr, TBool UseDense) {
+  if (!IsNode(EId)) {
+    // AddNode(NId);
+    return -1;
   }
-  if (KeyToIndexTypeE.IsKey(attr)) {
+  TInt location = CheckDenseOrSparseE(attr);
+  if (location==-1) {
+    AddIntVAttrE(attr, UseDense);
+    location = CheckDenseOrSparseE(attr);
+  }
+  if (UseDense) {
+    IAssertR(location != 0, TStr::Fmt("EdgeID %d exists for %s in sparse representation", EId, attr.CStr()));
     TVec<TIntV>& NewVec = VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2];
     NewVec[EdgeH.GetKeyId(EId)] = value;
   } else {
-    CurrLen = VecOfIntVecVecsE.Len();
-    KeyToIndexTypeE.AddDat(attr, TIntPr(IntVType, CurrLen));
-    TVec<TIntV> NewVec = TVec<TIntV>();
-    for (i = 0; i < MxEId; i++) {
-      NewVec.Ins(i, TIntV());
-    }
-    NewVec[EdgeH.GetKeyId(EId)] = value;
-    VecOfIntVecVecsE.Add(NewVec);
+    IAssertR(location != 1, TStr::Fmt("NodeId %d exists for %s in dense representation", EId, attr.CStr()));
+    THash<TInt, TIntV>& NewHash = VecOfIntHashVecsE[KeyToIndexTypeE.GetDat(attr).Val2];
+    NewHash.AddDat(EdgeH.GetKeyId(EId), value);
   }
   return 0;
 } 
 
-int TNEANet::AppendIntVAttrDatE(const int& EId, const TInt& value, const TStr& attr) {
-  TInt CurrLen;
-  if (!IsEdge(EId)) {
-    //AddEdge(EId);
-     return -1;
+int TNEANet::AppendIntVAttrDatE(const int& EId, const TInt& value, const TStr& attr, TBool UseDense) {
+  if (!IsNode(EId)) {
+    // AddNode(NId);
+    return -1;
   }
-  if (KeyToIndexTypeE.IsKey(attr)) {
+  TInt location = CheckDenseOrSparseE(attr);
+  if (location==-1) return -1;
+  if (UseDense) {
+    IAssertR(location != 0, TStr::Fmt("Edge %d exists for %s in sparse representation", EId, attr.CStr()));
     TVec<TIntV>& NewVec = VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2];
     NewVec[EdgeH.GetKeyId(EId)].Add(value);
   } else {
-    return -1;
+    IAssertR(location != 1, TStr::Fmt("Edge %d exists for %s in dense representation", EId, attr.CStr()));
+    THash<TInt, TIntV>& NewHash = VecOfIntHashVecsE[KeyToIndexTypeE.GetDat(attr).Val2];
+    NewHash[EdgeH.GetKeyId(EId)].Add(value);
   }
   return 0;
 }
@@ -1092,7 +1147,9 @@ TInt TNEANet::GetIntAttrDatN(const int& NId, const TStr& attr) {
 }
 
 TIntV TNEANet::GetIntVAttrDatN(const int& NId, const TStr& attr) const {
-  return VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)];
+  TInt location = CheckDenseOrSparseN(attr);
+  if (location != 0) return VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)];
+  else return VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)];
 }
 
 TStr TNEANet::GetStrAttrDatN(const int& NId, const TStr& attr) {
@@ -1128,7 +1185,9 @@ TInt TNEANet::GetIntAttrDatE(const int& EId, const TStr& attr) {
 }
 
 TIntV TNEANet::GetIntVAttrDatE(const int& EId, const TStr& attr) {
-  return VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)];
+  TInt location = CheckDenseOrSparseE(attr);
+  if (location != 0) return VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)];
+  else return VecOfIntHashVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)];
 }
 
 TStr TNEANet::GetStrAttrDatE(const int& EId, const TStr& attr) {
@@ -1168,7 +1227,9 @@ int TNEANet::DelAttrDatN(const int& NId, const TStr& attr) {
   } else if (vecType == FltType) {
     VecOfFltVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = GetFltAttrDefaultN(attr);
   } else if (vecType ==IntVType) {
-    VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TIntV();
+    TInt location = CheckDenseOrSparseN(attr);
+    if (location == 0) VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TIntV();
+    else VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TIntV();
   } else {
     return -1;
   }
@@ -1185,7 +1246,9 @@ int TNEANet::DelAttrDatE(const int& EId, const TStr& attr) {
   } else if (vecType == FltType) {
     VecOfFltVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)] = GetFltAttrDefaultE(attr);
   } else if (vecType == IntVType) {
-    VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)] = TIntV();
+    TInt location = CheckDenseOrSparseE(attr);
+    if (location == 0) VecOfIntHashVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)] = TIntV();
+    else VecOfIntVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)] = TIntV();
   } else {
     return -1;
   }
@@ -1211,13 +1274,21 @@ int TNEANet::AddIntAttrN(const TStr& attr, TInt defaultValue){
   return 0;
 }
 
-int TNEANet::AddIntVAttrN(const TStr& attr){
+int TNEANet::AddIntVAttrN(const TStr& attr, TBool UseDense){
   TInt CurrLen;
-  TVec<TIntV> NewVec;
-  CurrLen = VecOfIntVecVecsN.Len();
-  KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
-  NewVec = TVec<TIntV>(MxNId);
-  VecOfIntVecVecsN.Add(NewVec);
+  if (UseDense) {
+      CurrLen = VecOfIntVecVecsN.Len();
+      KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
+      KeyToDenseN.AddDat(attr, true);
+      TVec<TIntV> NewVec = TVec<TIntV>(MxNId);
+      VecOfIntVecVecsN.Add(NewVec);
+  } else {
+      CurrLen = VecOfIntHashVecsN.Len();
+      KeyToIndexTypeN.AddDat(attr, TIntPr(IntVType, CurrLen));
+      KeyToDenseN.AddDat(attr, false);
+      THash<TInt, TIntV> NewHash;
+      VecOfIntHashVecsN.Add(NewHash);
+  }
   return 0;
 }
 
@@ -1280,17 +1351,21 @@ int TNEANet::AddIntAttrE(const TStr& attr, TInt defaultValue){
   return 0;
 }
 
-int TNEANet::AddIntVAttrE(const TStr& attr){
-  int i;
+int TNEANet::AddIntVAttrE(const TStr& attr, TBool UseDense){
   TInt CurrLen;
-  TVec<TIntV> NewVec;
-  CurrLen = VecOfIntVecVecsE.Len();
-  KeyToIndexTypeE.AddDat(attr, TIntPr(IntVType, CurrLen));
-  NewVec = TVec<TIntV>();
-  for (i = 0; i < MxEId; i++) {
-    NewVec.Ins(i, TIntV());
+  if (UseDense) {
+      CurrLen = VecOfIntVecVecsE.Len();
+      KeyToIndexTypeE.AddDat(attr, TIntPr(IntVType, CurrLen));
+      KeyToDenseE.AddDat(attr, true);
+      TVec<TIntV> NewVec = TVec<TIntV>(MxEId);
+      VecOfIntVecVecsE.Add(NewVec);
+  } else {
+      CurrLen = VecOfIntHashVecsE.Len();
+      KeyToIndexTypeE.AddDat(attr, TIntPr(IntVType, CurrLen));
+      KeyToDenseE.AddDat(attr, false);
+      THash<TInt, TIntV> NewHash;
+      VecOfIntHashVecsE.Add(NewHash);
   }
-  VecOfIntVecVecsE.Add(NewVec);
   return 0;
 }
 
@@ -1350,7 +1425,10 @@ int TNEANet::DelAttrN(const TStr& attr) {
       FltDefaultsN.DelKey(attr);
     }
   } else if (vecType == IntVType) {
-    VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2] = TVec<TIntV>();
+    TInt location = CheckDenseOrSparseN(attr);
+    if (location == 1) VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2] = TVec<TIntV>();
+    else VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2] = THash<TInt, TIntV>();
+    KeyToDenseN.DelKey(attr);
   } else {
     return -1;
   }

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1907,6 +1907,16 @@ private:
     }
   };
 
+  class LoadHashOfVecFunctor {
+  public:
+    LoadHashOfVecFunctor() {}
+    template<typename TElem>
+    void operator() (THash<TInt, TVec<TElem> >* n, TShMIn& ShMin) {
+      LoadVecFunctor f;
+      n->LoadShM(ShMin, f);
+    }
+  };
+
 protected:
   /// Return 1 if in Dense, 0 if in Sparse, -1 if neither 
   TInt CheckDenseOrSparseN(const TStr& attr) const {
@@ -1976,7 +1986,8 @@ public:
     VecOfIntVecsN.Save(SOut); VecOfIntVecsE.Save(SOut);
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
-    VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut); 
+    VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
+    VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut); 
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Saves the graph to a (binary) stream SOut. Available for backwards compatibility.
   void Save_V1(TSOut& SOut) const {

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1907,6 +1907,7 @@ private:
     }
   };
 
+protected:
   /// Return 1 if in Dense, 0 if in Sparse, -1 if neither 
   TInt CheckDenseOrSparseN(const TStr& attr) const {
     if (!KeyToDenseN.IsKey(attr)) return -1;
@@ -1923,47 +1924,52 @@ private:
 
 public:
   TNEANet() : CRef(), MxNId(0), MxEId(0), NodeH(), EdgeH(),
-    KeyToIndexTypeN(), KeyToIndexTypeE(), IntDefaultsN(), IntDefaultsE(),
+    KeyToIndexTypeN(), KeyToIndexTypeE(), KeyToDenseN(), KeyToDenseE(), IntDefaultsN(), IntDefaultsE(),
     StrDefaultsN(), StrDefaultsE(), FltDefaultsN(), FltDefaultsE(),
     VecOfIntVecsN(), VecOfIntVecsE(), VecOfStrVecsN(), VecOfStrVecsE(),
-    VecOfFltVecsN(), VecOfFltVecsE(),  VecOfIntVecVecsN(), VecOfIntVecVecsE(), SAttrN(), SAttrE(){ }
+    VecOfFltVecsN(), VecOfFltVecsE(),  VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE(){ }
   /// Constructor that reserves enough memory for a graph of nodes and edges.
   explicit TNEANet(const int& Nodes, const int& Edges) : CRef(),
-    MxNId(0), MxEId(0), NodeH(), EdgeH(), KeyToIndexTypeN(), KeyToIndexTypeE(),
+    MxNId(0), MxEId(0), NodeH(), EdgeH(), KeyToIndexTypeN(), KeyToIndexTypeE(), KeyToDenseN(), KeyToDenseE(),
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
-    VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(), SAttrN(), SAttrE()
+    VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE()
     { Reserve(Nodes, Edges); }
   TNEANet(const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
-    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(), KeyToIndexTypeE(),
+    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(), KeyToIndexTypeE(), KeyToDenseN(), KeyToDenseE(),
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
-    VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(), SAttrN(), SAttrE() { }
+    VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE() { }
   /// Constructor for loading the graph from a (binary) stream SIn.
   TNEANet(TSIn& SIn) : MxNId(SIn), MxEId(SIn), NodeH(SIn), EdgeH(SIn),
-    KeyToIndexTypeN(SIn), KeyToIndexTypeE(SIn), IntDefaultsN(SIn), IntDefaultsE(SIn),
+    KeyToIndexTypeN(SIn), KeyToIndexTypeE(SIn), KeyToDenseN(SIn), KeyToDenseE(SIn), IntDefaultsN(SIn), IntDefaultsE(SIn),
     StrDefaultsN(SIn), StrDefaultsE(SIn), FltDefaultsN(SIn), FltDefaultsE(SIn),
     VecOfIntVecsN(SIn), VecOfIntVecsE(SIn), VecOfStrVecsN(SIn),VecOfStrVecsE(SIn),
-    VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), SAttrN(SIn), SAttrE(SIn) { }
+    VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), VecOfIntHashVecsN(SIn), VecOfIntHashVecsE(SIn),
+    SAttrN(SIn), SAttrE(SIn) { }
 protected:
   TNEANet(const TNEANet& Graph, bool modeSubGraph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
-    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(), KeyToIndexTypeE(Graph.KeyToIndexTypeE),
+    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(), KeyToIndexTypeE(Graph.KeyToIndexTypeE), KeyToDenseN(), KeyToDenseE(Graph.KeyToDenseE),
     IntDefaultsN(Graph.IntDefaultsN), IntDefaultsE(Graph.IntDefaultsE), StrDefaultsN(Graph.StrDefaultsN), StrDefaultsE(Graph.StrDefaultsE),
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
-    VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE) { }
+    VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE) { }
   TNEANet(bool copyAll, const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
-    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(Graph.KeyToIndexTypeN), KeyToIndexTypeE(Graph.KeyToIndexTypeE),
+    NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(Graph.KeyToIndexTypeN), KeyToIndexTypeE(Graph.KeyToIndexTypeE), KeyToDenseN(Graph.KeyToDenseN), KeyToDenseE(Graph.KeyToDenseE),
     IntDefaultsN(Graph.IntDefaultsN), IntDefaultsE(Graph.IntDefaultsE), StrDefaultsN(Graph.StrDefaultsN), StrDefaultsE(Graph.StrDefaultsE),
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
-    VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
+    VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
   // virtual ~TNEANet() { }
 public:
   /// Saves the graph to a (binary) stream SOut. Expects data structures for sparse attributes.
   void Save(TSOut& SOut) const {
     MxNId.Save(SOut); MxEId.Save(SOut); NodeH.Save(SOut); EdgeH.Save(SOut);
     KeyToIndexTypeN.Save(SOut); KeyToIndexTypeE.Save(SOut);
+    KeyToDenseN.Save(SOut); KeyToDenseE.Save(SOut);
     IntDefaultsN.Save(SOut); IntDefaultsE.Save(SOut);
     StrDefaultsN.Save(SOut); StrDefaultsE.Save(SOut);
     FltDefaultsN.Save(SOut); FltDefaultsE.Save(SOut);
@@ -1982,6 +1988,18 @@ public:
     VecOfIntVecsN.Save(SOut); VecOfIntVecsE.Save(SOut);
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut); }
+  /// Saves the graph without any sparse data structures. Available for backwards compatibility
+  void Save_V2(TSOut& SOut) const {
+    MxNId.Save(SOut); MxEId.Save(SOut); NodeH.Save(SOut); EdgeH.Save(SOut);
+    KeyToIndexTypeN.Save(SOut); KeyToIndexTypeE.Save(SOut);
+    IntDefaultsN.Save(SOut); IntDefaultsE.Save(SOut);
+    StrDefaultsN.Save(SOut); StrDefaultsE.Save(SOut);
+    FltDefaultsN.Save(SOut); FltDefaultsE.Save(SOut);
+    VecOfIntVecsN.Save(SOut); VecOfIntVecsE.Save(SOut);
+    VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
+    VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
+    VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut); 
+    SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Static cons returns pointer to graph. Ex: PNEANet Graph=TNEANet::New().
   static PNEANet New() { return PNEANet(new TNEANet()); }
   /// Static constructor that returns a pointer to the graph and reserves enough memory for Nodes nodes and Edges edges. ##TNEANet::New
@@ -2002,6 +2020,24 @@ public:
     Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn);
     return Graph;
   }
+
+  /// Static constructor that loads the graph from a stream SIn and returns a pointer to it. Backwards compatible without Sparse
+  static PNEANet Load_V2(TSIn& SIn) {
+    PNEANet Graph = PNEANet(new TNEANet());
+    Graph->MxNId.Load(SIn); Graph->MxEId.Load(SIn);
+    Graph->NodeH.Load(SIn); Graph->EdgeH.Load(SIn);
+    Graph->KeyToIndexTypeN.Load(SIn); Graph->KeyToIndexTypeE.Load(SIn);
+    Graph->IntDefaultsN.Load(SIn); Graph->IntDefaultsE.Load(SIn);
+    Graph->StrDefaultsN.Load(SIn); Graph->StrDefaultsE.Load(SIn);
+    Graph->FltDefaultsN.Load(SIn); Graph->FltDefaultsE.Load(SIn);
+    Graph->VecOfIntVecsN.Load(SIn); Graph->VecOfIntVecsE.Load(SIn);
+    Graph->VecOfStrVecsN.Load(SIn); Graph->VecOfStrVecsE.Load(SIn);
+    Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn);
+    Graph->VecOfIntVecVecsN.Load(SIn); Graph->VecOfIntVecVecsE.Load(SIn);
+    Graph->SAttrN.Load(SIn); Graph->SAttrE.Load(SIn);
+    return Graph;
+  }
+
   /// load network from shared memory for this network
   void LoadNetworkShm(TShMIn& ShMin);
   /// static constructor to create and load a network from memory.


### PR DESCRIPTION
Change TNEANet's VecOfIntVecVecs to use sparse representation (VecOfIntHashVecs) to speed up computation time